### PR TITLE
Fixed escaping of hdfmonkey calls

### DIFF
--- a/Scripts/nextbuild.py
+++ b/Scripts/nextbuild.py
@@ -121,7 +121,7 @@ def GenerateLoader():
             txt2nextbasic.main()
             # copies the autoexec.bas 
             if nextzxos == 1: 
-                subprocess.run([EMU_DIR+'\hdfmonkey.exe','put','/CSpect/cspect-next-2gb.img','autoexec.bas','/nextzxos/autoexec.bas'])
+                subprocess.run([EMU_DIR+'\\hdfmonkey.exe','put','/CSpect/cspect-next-2gb.img','autoexec.bas','/nextzxos/autoexec.bas'])
         else:
             txt2nextbasic.b_auto = 0 
 
@@ -134,12 +134,12 @@ def GenerateLoader():
             txt2nextbasic.b_auto = 0 
             txt2nextbasic.main()
 
-            subprocess.run([EMU_DIR+'\hdfmonkey.exe','put','/CSpect/cspect-next-2gb.img',loaderfile,'/dev/'+loaderfile])
+            subprocess.run([EMU_DIR+'\\hdfmonkey.exe','put','/CSpect/cspect-next-2gb.img',loaderfile,'/dev/'+loaderfile])
         
-        subprocess.run([EMU_DIR+'\hdfmonkey.exe','put','/CSpect/cspect-next-2gb.img',filenamenoext+ext,'/dev/'+outfilenoext+ext])
-        #subprocess.run([EMU_DIR+'\launchnextzxos.bat',head_tail[0]+'\\Memory.txt',EMU_DIR])
+        subprocess.run([EMU_DIR+'\\hdfmonkey.exe','put','/CSpect/cspect-next-2gb.img',filenamenoext+ext,'/dev/'+outfilenoext+ext])
+        #subprocess.run([EMU_DIR+'\\launchnextzxos.bat',head_tail[0]+'\\Memory.txt',EMU_DIR])
         if noemu == 0:
-            subprocess.Popen([EMU_DIR+'\launchnextzxos.bat',head_tail[0]+'\\Memory.txt',EMU_DIR])
+            subprocess.Popen([EMU_DIR+'\\launchnextzxos.bat',head_tail[0]+'\\Memory.txt',EMU_DIR])
 
 
 def CreateNEXFile():


### PR DESCRIPTION
Currently when running a build on OSX the start of the log contains the warnings about invalid escape characters:
```
/opt/nextbuild/Sources/./../Scripts/nextbuild.py:124: SyntaxWarning: invalid escape sequence '\h'
  subprocess.run([EMU_DIR+'\hdfmonkey.exe','put','/CSpect/cspect-next-2gb.img','autoexec.bas','/nextzxos/autoexec.bas'])
/opt/nextbuild/Sources/./../Scripts/nextbuild.py:137: SyntaxWarning: invalid escape sequence '\h'
  subprocess.run([EMU_DIR+'\hdfmonkey.exe','put','/CSpect/cspect-next-2gb.img',loaderfile,'/dev/'+loaderfile])
/opt/nextbuild/Sources/./../Scripts/nextbuild.py:139: SyntaxWarning: invalid escape sequence '\h'
  subprocess.run([EMU_DIR+'\hdfmonkey.exe','put','/CSpect/cspect-next-2gb.img',filenamenoext+ext,'/dev/'+outfilenoext+ext])
/opt/nextbuild/Sources/./../Scripts/nextbuild.py:142: SyntaxWarning: invalid escape sequence '\l'
  subprocess.Popen([EMU_DIR+'\launchnextzxos.bat',head_tail[0]+'\\Memory.txt',EMU_DIR])
```

This is the simple fix to remove this complaints. 

Note: this will not enable usage of `'!nextos` directive on OSX / Linux, but just remove warnings about invalid files. 

On top of that hdfmonkey.exe doesn't seem to be a part of bundled CSpect version as well as launchnextzxos.bat