### PR TITLE
Fix capitlisation of .NEX to .nex in tasks.json.

### DIFF
--- a/Sources/.vscode/tasks.json
+++ b/Sources/.vscode/tasks.json
@@ -41,9 +41,9 @@
         {
             "label": "Run in Cspect",
             "type": "shell",
-            "command": "mono ./../Emu/CSpect/CSpect.exe -16bit -nojoy -brk -tv -vsync -nextrom -map=${fileDirname}/${fileBasenameNoExtension}.map -zxnext -fill=00 -mmc=${fileDirname}/data/ ${fileDirname}/${fileBasenameNoExtension}.NEX",
+            "command": "mono ./../Emu/CSpect/CSpect.exe -16bit -nojoy -brk -tv -vsync -nextrom -map=${fileDirname}/${fileBasenameNoExtension}.map -zxnext -fill=00 -mmc=${fileDirname}/data/ ${fileDirname}/${fileBasenameNoExtension}.nex",
             "windows": {
-                "command": "./../Emu/CSpect/CSpect.exe -w3 -16bit -brk -tv -vsync -nextrom -map=${fileDirname}/${fileBasenameNoExtension}.map -zxnext -mmc=${fileDirname}\\data\\ ${fileDirname}/${fileBasenameNoExtension}.NEX"
+                "command": "./../Emu/CSpect/CSpect.exe -w3 -16bit -brk -tv -vsync -nextrom -map=${fileDirname}/${fileBasenameNoExtension}.map -zxnext -mmc=${fileDirname}\\data\\ ${fileDirname}/${fileBasenameNoExtension}.nex"
             },
             "dependsOn": [
                 "Compile ZXbasic"
@@ -121,7 +121,7 @@
         {
             "label": "Parse source file",
             "type": "shell",
-            "command": "mono ./../Emu/CSpect/CSpect.exe -16bit -nojoy -brk -tv -vsync -nextrom -map=${fileDirname}/memory.txt -zxnext -fill=00 -mmc=${fileDirname}/data/ ${fileDirname}/${fileBasenameNoExtension}.NEX",
+            "command": "mono ./../Emu/CSpect/CSpect.exe -16bit -nojoy -brk -tv -vsync -nextrom -map=${fileDirname}/memory.txt -zxnext -fill=00 -mmc=${fileDirname}/data/ ${fileDirname}/${fileBasenameNoExtension}.nex",
             "isBackground": true,
             "windows": {
                 "command": "./../zxbasic/python/python.exe",


### PR DESCRIPTION
nextbuild.py outputs .nex files, all lowercase extension, under Linux so that's what we need to use for the extensions in tasks.json.