### PR TITLE
Remove -vsync switch from tasks.json CSpect commands

### DIFF
--- a/Sources/.vscode/tasks.json
+++ b/Sources/.vscode/tasks.json
@@ -41,9 +41,9 @@
         {
             "label": "Run in Cspect",
             "type": "shell",
-            "command": "mono ./../Emu/CSpect/CSpect.exe -16bit -nojoy -brk -tv -vsync -nextrom -map=${fileDirname}/${fileBasenameNoExtension}.map -zxnext -fill=00 -mmc=${fileDirname}/data/ ${fileDirname}/${fileBasenameNoExtension}.nex",
+            "command": "mono ./../Emu/CSpect/CSpect.exe -16bit -nojoy -brk -tv -nextrom -map=${fileDirname}/${fileBasenameNoExtension}.map -zxnext -fill=00 -mmc=${fileDirname}/data/ ${fileDirname}/${fileBasenameNoExtension}.nex",
             "windows": {
-                "command": "./../Emu/CSpect/CSpect.exe -w3 -16bit -brk -tv -vsync -nextrom -map=${fileDirname}/${fileBasenameNoExtension}.map -zxnext -mmc=${fileDirname}\\data\\ ${fileDirname}/${fileBasenameNoExtension}.nex"
+                "command": "./../Emu/CSpect/CSpect.exe -w3 -16bit -brk -tv -nextrom -map=${fileDirname}/${fileBasenameNoExtension}.map -zxnext -mmc=${fileDirname}\\data\\ ${fileDirname}/${fileBasenameNoExtension}.nex"
             },
             "dependsOn": [
                 "Compile ZXbasic"
@@ -121,7 +121,7 @@
         {
             "label": "Parse source file",
             "type": "shell",
-            "command": "mono ./../Emu/CSpect/CSpect.exe -16bit -nojoy -brk -tv -vsync -nextrom -map=${fileDirname}/memory.txt -zxnext -fill=00 -mmc=${fileDirname}/data/ ${fileDirname}/${fileBasenameNoExtension}.nex",
+            "command": "mono ./../Emu/CSpect/CSpect.exe -16bit -nojoy -brk -tv -nextrom -map=${fileDirname}/memory.txt -zxnext -fill=00 -mmc=${fileDirname}/data/ ${fileDirname}/${fileBasenameNoExtension}.nex",
             "isBackground": true,
             "windows": {
                 "command": "./../zxbasic/python/python.exe",


### PR DESCRIPTION
I have been testing NextBuild with pong.bas under Debian. I get less than 1 fps when running pong.nex when using the -vsync option with CSpect. It runs perfectly fine without -vsync.

-vsync only seem to work when you use the -60 option and -sound but -sound disables the sound so I think we're best just not using -vsync.